### PR TITLE
python 2.7.11 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ This will product documentation like this: [ACS 4.9.0 Release Notes | Fixed Issu
 DEPENDENCIES
 ============
 
+python 2.7.11+
+
 `api_changes.py`
 ----------------
 


### PR DESCRIPTION
2.7.5 doesn't work due to module name changes in 2.7.11 which the script is referencing (2.7.5 is default version on CentOS 7.7)